### PR TITLE
Fix statuscolor

### DIFF
--- a/Material Dark/config.xml
+++ b/Material Dark/config.xml
@@ -18,7 +18,7 @@
       backcolor="#212121"
       menubackgroundcolor="#212121"
       menutextcolor="#ffffff"
-      statuscolor="#212121" />
+      statuscolor="#ffffff" />
     <toolbar_icon
       back="ViewPreviousImage.svg"
       next="ViewNextImage.svg"

--- a/Material Light/config.xml
+++ b/Material Light/config.xml
@@ -18,7 +18,7 @@
       backcolor="#fafafa"
       menubackgroundcolor="#fafafa"
       menutextcolor="#000000"
-      statuscolor="#fafafa" />
+      statuscolor="#000000" />
     <toolbar_icon
       back="ViewPreviousImage.svg"
       next="ViewNextImage.svg"


### PR DESCRIPTION
Presently the `statuscolor` value causes the text in `Color picker` window and `Settings` > `Toolbar` menu to become hidden. The fix is similar to how it's done in the more recently updated [Windows 10 Dark](https://imageglass.org/theme/windows-10-dark-27) theme. Didn't see any colour mismatches at any other place.

![image](https://user-images.githubusercontent.com/20906143/72611907-1709ba80-394d-11ea-8b64-56d54c1cc524.png) ![image](https://user-images.githubusercontent.com/20906143/72611954-3b659700-394d-11ea-959f-c7ec3e7971ca.png) 

![image](https://user-images.githubusercontent.com/20906143/72612132-afa03a80-394d-11ea-9e5d-bdf59752fa90.png) ![image](https://user-images.githubusercontent.com/20906143/72612209-e6765080-394d-11ea-80d8-50a2b3f18728.png)

![image](https://user-images.githubusercontent.com/20906143/72612468-acf21500-394e-11ea-9f4d-4f885fdaf6c1.png) ![image](https://user-images.githubusercontent.com/20906143/72612585-03f7ea00-394f-11ea-8bbb-adb87e92425c.png)

![image](https://user-images.githubusercontent.com/20906143/72612365-597fc700-394e-11ea-973a-a67b82e3b026.png) ![image](https://user-images.githubusercontent.com/20906143/72612559-f478a100-394e-11ea-8ba5-38d61c201ced.png)








